### PR TITLE
Fix typo in README (run_batch returns list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,11 @@ results = manifest.batch_run(prompt, ["Laurel", "Avanika"])
 
 If something doesn't go right, you can also ask to get a raw manifest Response.
 ```python
-result_object = manifest.batch_run(prompt, ["Laurel", "Avanika"], return_response=True)
-print(result_object.get_request())
-print(result_object.is_cached())
-print(result_object.get_json_response())
+result_objects = manifest.batch_run(prompt, ["Laurel", "Avanika"], return_response=True)
+for result_object in result_objects:
+    print(result_object.get_request())
+    print(result_object.is_cached())
+    print(result_object.get_json_response())
 ```
 
 By default, we do not truncate results based on a stop token. You can change this by either passing a new stop token to a Manifest session or to a `run` or `batch_run`.


### PR DESCRIPTION
In `result_object = manifest.run_batch(prompt, ["Laurel", "Avanika"], return_response=True)`, the return type of `run_batch` is a list of response objects, not a response object. This PR fixes a bug in the demo code to print only after looping through the response objects.