### PR TITLE
Hash postgres keys to support long documents

### DIFF
--- a/manifest/caches/postgres.py
+++ b/manifest/caches/postgres.py
@@ -119,11 +119,7 @@ class PostgresCache(Cache):
             table: table to set key in.
         """
         key = self._hash_key(key, table)
-        request = (
-            self.session.query(Request)
-            .filter_by(key=key)
-            .first()
-        )
+        request = self.session.query(Request).filter_by(key=key).first()
         if request:
             request.response = value  # type: ignore
         else:


### PR DESCRIPTION
Long documents can't be indexed by postgres, so am now hashing the values to use as keys.  

```
'index row size 3440 exceeds btree version 4 maximum 2704 for index "requests_pkey"', 'D': 'Index row references tuple (0,5) in relation "requests".', 'H': 'Values larger than 1/3 of a buffer page cannot be indexed.\nConsider a function index of an MD5 hash of the value, or use full text indexing.',
```