### PR TITLE
Added upper limit to pydantic version due to bug in latest version

### DIFF
--- a/manifest/clients/openai.py
+++ b/manifest/clients/openai.py
@@ -11,6 +11,7 @@ from manifest.request import LMRequest, Request
 logger = logging.getLogger(__name__)
 
 OPENAI_ENGINES = {
+    "gpt-3.5-turbo-instruct",
     "text-davinci-003",
     "text-davinci-002",
     "text-davinci-001",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ VERSION = main_ns["__version__"]
 # What packages are required for this module to be executed?
 REQUIRED = [
     "numpy>=1.20.0",
-    "pydantic>=1.9.0",
+    "pydantic>=1.9.0,<2.0",
     "redis>=4.3.1",
     "requests>=2.27.1",
     "aiohttp>=3.8.0",


### PR DESCRIPTION
For `pydantic` version 2.0 and up, even with valid string inputs, the following error can arise:

```
  Input should be a valid string [type=string_type, input_value=5329, input_type=int]
    For further information visit https://errors.pydantic.dev/2.4/v/string_type
```

e.g.

```python
from manifest import Manifest

llm = Manifest(client_name="huggingface", client_connection = f"http://localhost:{port}")
llm.run("hello this is a test")
```

This error does not occur if I use an earlier version of `pydantic`. I have tested the above code example with the following versions.

Version | Error-free
--- | ---
2.4.2 | :negative_squared_cross_mark:
2.4.0 | :negative_squared_cross_mark:
2.3.0 | :negative_squared_cross_mark: 
2.2.0 | :negative_squared_cross_mark: 
2.1.0 | :negative_squared_cross_mark: 
2.0 | :negative_squared_cross_mark: 
1.10.13 | :white_check_mark:
1.10.0 | :white_check_mark: 